### PR TITLE
Demo bug

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -21,10 +21,14 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
+import { DragdollHook } from "./hooks/DragdollHook";
+
+let hooks = {DragdollHook: DragdollHook};
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
+  hooks: hooks,
   params: {_csrf_token: csrfToken}
 })
 

--- a/assets/js/hooks/DragdollHook.js
+++ b/assets/js/hooks/DragdollHook.js
@@ -1,0 +1,24 @@
+import {
+  PointerSensor,
+  KeyboardSensor,
+  Draggable,
+  createPointerSensorStartPredicate,
+} from 'dragdoll';
+
+const DragdollHook = {
+  mounted() {
+    this.pointerSensor = new PointerSensor(this.el);
+    this.keyboardSensor = new KeyboardSensor(this.el);
+    this.draggable = new Draggable([this.pointerSensor, this.keyboardSensor], {
+      getElements: () => [this.el],
+      startPredicate: createPointerSensorStartPredicate(),
+    });
+  },
+  destroyed() {
+    this.draggable.destroy();
+    this.pointerSensor.destroy();
+    this.keyboardSensor.destroy();
+  }
+};
+
+export { DragdollHook };

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "assets",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "dragdoll": "^0.4.0",
+        "eventti": "^4.0.0",
+        "mezr": "^1.1.0",
+        "tikki": "^3.0.1"
+      }
+    },
+    "node_modules/dragdoll": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/dragdoll/-/dragdoll-0.4.0.tgz",
+      "integrity": "sha512-OTItNaDB9cU7l1UKZkcTOVT3XiQM4wBxxJkVgqoaTb0ybSxKFX78Vq7qXReg+zCPrZcQVIwW+Hcik8VyShp7Lw==",
+      "peerDependencies": {
+        "eventti": "^4.0.0",
+        "mezr": "^1.1.0",
+        "tikki": "^3.0.1"
+      }
+    },
+    "node_modules/eventti": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventti/-/eventti-4.0.0.tgz",
+      "integrity": "sha512-1fEd/Uq349E5GEagGDfU0DZX2K1xhWtcTBdTmX9vVNci0Vlo0SUQ4Yx0OgQMHx0PIZW4VRCFNqt2e5UW6qfSTA=="
+    },
+    "node_modules/mezr": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mezr/-/mezr-1.1.0.tgz",
+      "integrity": "sha512-KGP0ZnmCHd8VepU4+91JdxnIBJ5KtAPY/qyyRFp+JhutVxumZodJyLHhi7aWJuqO9e0CIeJhypfMP2No9BNm+Q=="
+    },
+    "node_modules/tikki": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tikki/-/tikki-3.0.1.tgz",
+      "integrity": "sha512-tspgQxMlGfNuByBcXcjc9Lms+HE91SmVec/NpLwQkxEmxqM1NWiX3WLHqGHixC6TyG1J9nNA3MdHUNfiNeJuMw==",
+      "peerDependencies": {
+        "eventti": "^4.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "dragdoll": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/dragdoll/-/dragdoll-0.4.0.tgz",
+      "integrity": "sha512-OTItNaDB9cU7l1UKZkcTOVT3XiQM4wBxxJkVgqoaTb0ybSxKFX78Vq7qXReg+zCPrZcQVIwW+Hcik8VyShp7Lw==",
+      "requires": {}
+    },
+    "eventti": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventti/-/eventti-4.0.0.tgz",
+      "integrity": "sha512-1fEd/Uq349E5GEagGDfU0DZX2K1xhWtcTBdTmX9vVNci0Vlo0SUQ4Yx0OgQMHx0PIZW4VRCFNqt2e5UW6qfSTA=="
+    },
+    "mezr": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mezr/-/mezr-1.1.0.tgz",
+      "integrity": "sha512-KGP0ZnmCHd8VepU4+91JdxnIBJ5KtAPY/qyyRFp+JhutVxumZodJyLHhi7aWJuqO9e0CIeJhypfMP2No9BNm+Q=="
+    },
+    "tikki": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tikki/-/tikki-3.0.1.tgz",
+      "integrity": "sha512-tspgQxMlGfNuByBcXcjc9Lms+HE91SmVec/NpLwQkxEmxqM1NWiX3WLHqGHixC6TyG1J9nNA3MdHUNfiNeJuMw==",
+      "requires": {}
+    }
+  }
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "dragdoll": "^0.4.0",
+    "eventti": "^4.0.0",
+    "mezr": "^1.1.0",
+    "tikki": "^3.0.1"
+  }
+}

--- a/lib/drgr_web/live/demo_live.ex
+++ b/lib/drgr_web/live/demo_live.ex
@@ -1,0 +1,21 @@
+defmodule DrgrWeb.DemoLive do
+  @moduledoc false
+  use DrgrWeb, :live_view
+
+  @impl true
+  def render(%{} = assigns) do
+    ~H"""
+    <div
+      id="demo-dragdoll"
+      phx-hook="DragdollHook"
+      class={[
+        "draggable",
+        "border-4 border-cyan-500",
+        "rounded-lg text-center w-32 cursor-grab"
+      ]}
+    >
+      I should be draggable
+    </div>
+    """
+  end
+end

--- a/lib/drgr_web/live/demo_live.ex
+++ b/lib/drgr_web/live/demo_live.ex
@@ -2,10 +2,17 @@ defmodule DrgrWeb.DemoLive do
   @moduledoc false
   use DrgrWeb, :live_view
 
+  def mount(_params, _session, socket) do
+    socket
+    |> assign(:connected?, connected?(socket))
+    |> then(&{:ok, &1})
+  end
+
   @impl true
   def render(%{} = assigns) do
     ~H"""
     <div
+      :if={@connected?}
       id="demo-dragdoll"
       phx-hook="DragdollHook"
       class={[

--- a/lib/drgr_web/router.ex
+++ b/lib/drgr_web/router.ex
@@ -18,6 +18,7 @@ defmodule DrgrWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+    live "/demo", DemoLive
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
This is to demonstrate my problem trying to do a naive integration of `dragdoll`  in a  PhoenixLiveView project.

re: https://github.com/niklasramo/dragdoll/issues/10

The project was generated like this:

```
mix phx.new --no-dashboard --no-ecto drgr
```

The libs were installed like this:

```
npm install --prefix assets --save dragdoll eventti tikki mezr
```

Then everything else I did is captured by this PR (Check the "Files changed" section).

I suspected the problem had something to do with the "double mount" that LiveViews do (https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#c:mount/3). However, I only mount the the draggable element on the second mount, so the JS is only called once.

I have no other ideas or information.